### PR TITLE
wc_heading shortcode doesn't output valid HTML

### DIFF
--- a/includes/shortcode-functions.php
+++ b/includes/shortcode-functions.php
@@ -832,7 +832,7 @@ if( !function_exists('wc_shortcodes_heading') ) {
 		if ( $icon_left ) $output .= '<i class="wc-shortcodes-button-icon-left icon-'. $icon_left .'"></i>';
 			$output .= $title;
 		if ( $icon_right ) $output .= '<i class="wc-shortcodes-button-icon-right icon-'. $icon_right .'"></i>';
-		$output .= '</'.$type.'></span>';
+		$output .= '</span></'.$type.'>';
 
 		if ( 'h1' == $type )
 			$output = '<header class="entry-header">'. $output . '</header>';


### PR DESCRIPTION
h and span closing tag positions are swapped so the shortcode doesn't output valid HTML.
